### PR TITLE
Add Nix language support

### DIFF
--- a/indent-bars.el
+++ b/indent-bars.el
@@ -1125,6 +1125,10 @@ Adapted from `highlight-indentation-mode'."
     cobol-tab-width)
    ((or (derived-mode-p 'go-ts-mode) (derived-mode-p 'go-mode))
     tab-width)
+   ((derived-mode-p 'nix-mode)
+    tab-width)
+   ((and (derived-mode-p 'nix-ts-mode) (boundp 'nix-ts-mode-indent-offset))
+    nix-ts-mode-indent-offset)
    ((and (boundp 'standard-indent) standard-indent))
    (t 4))) 				; backup
 


### PR DESCRIPTION
Nix usually has an indentation size of 2, so the fallback value of 4 is not suitable.