### PR TITLE
Add support for yaml-pro-ts-mode

### DIFF
--- a/indent-bars.el
+++ b/indent-bars.el
@@ -1640,7 +1640,7 @@ Adapted from `highlight-indentation-mode'."
     (symbol-value c-ts-common-indent-offset))
    ((and (derived-mode-p 'yaml-mode) (boundp 'yaml-indent-offset))
     yaml-indent-offset)
-   ((and (derived-mode-p 'yaml-pro-mode) (boundp 'yaml-pro-indent))
+   ((and (or (bound-and-true-p yaml-pro-mode) (bound-and-true-p yaml-pro-ts-mode)) (boundp 'yaml-pro-indent))
     yaml-pro-indent)
    ((and (derived-mode-p 'elixir-mode) (boundp 'elixir-smie-indent-basic))
     elixir-smie-indent-basic)


### PR DESCRIPTION
`(derived-mode-p 'yaml-pro-mode)` does not evaluate to `t` in a `yaml-pro-mode` buffer, and the same goes for the `yaml-pro-ts-mode` equivalent. 

This is probably because `yaml-pro-mode` is not actually derived from `yaml-pro-mode` ...

This PR should handle this correctly and also add proper guessing support for the `-ts-` version.