### PR TITLE
Add `r-ts-mode` and `ess-mode` to `indent-bars--guess-spacing`

### DIFF
--- a/indent-bars.el
+++ b/indent-bars.el
@@ -1766,7 +1766,7 @@ Adapted from `highlight-indentation-mode'."
     r-ts-mode-indent-offset)
    ((and (derived-mode-p 'r-ts-mode) (boundp 'r-ts-mode-indent-level))
     r-ts-mode-indent-level)
-   ((and (derived-mode-p 'ess-r-mode) (boundp 'ess-indent-offset))
+   ((and (derived-mode-p 'ess-mode) (boundp 'ess-indent-offset))
     ess-indent-offset)
    ((and (boundp 'standard-indent) standard-indent))
    (t 4))) 				; backup

--- a/indent-bars.el
+++ b/indent-bars.el
@@ -1762,6 +1762,12 @@ Adapted from `highlight-indentation-mode'."
     tcl-indent-level)
    ((and (derived-mode-p 'haml-mode) (boundp 'haml-indent-offset))
     haml-indent-offset)
+   ((and (derived-mode-p 'r-ts-mode) (boundp 'r-ts-mode-indent-offset))
+    r-ts-mode-indent-offset)
+   ((and (derived-mode-p 'r-ts-mode) (boundp 'r-ts-mode-indent-level))
+    r-ts-mode-indent-level)
+   ((and (derived-mode-p 'ess-r-mode) (boundp 'ess-indent-offset))
+    ess-indent-offset)
    ((and (boundp 'standard-indent) standard-indent))
    (t 4))) 				; backup
 


### PR DESCRIPTION
Add three branches to the `cond` ladder: two for `r-ts-mode`, one for `ess-mode`.

R's tree-sitter mode needs a check for `r-ts-mode-indent-level` rather than `r-ts-mode-indent-offset` as [ESR calls it `r-ts-mode-indent-level`](https://codeberg.org/teoten/esr/src/commit/2dc0efe520152d9f80848bd5a180488ac4896c4a/esr.el#L56-L59).  I've included `r-ts-mode-indent-offset` in deference to the de facto standard naming convention, and I'll probably suggest a change in ESR.

`ess-r-mode` derives from `ess-mode`, so I've chosen the more general case in the event the mode is, say, `ess-julia-mode`.

A short test on my machine shows this is working for `r-ts-mode` buffers.
